### PR TITLE
[REFACTOR] CICD 플로우 수정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -55,27 +55,23 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
 
-      - name: Setup GCP Auth
-        uses: 'google-github-actions/auth@v2'
+      - name: Docker build
+        run: |
+          echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_EMAIL }} --password-stdin
+          docker build -t ${{ secrets.DOCKERHUB_REPOSITORY }} .
+          docker tag ${{ secrets.DOCKERHUB_REPOSITORY }} ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${{github.sha}}
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${{github.sha}}
+
+      - name: Deploy
+        uses: appleboy/ssh-action@master
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Set up Cloud SDK
-        uses: 'google-github-actions/setup-gcloud@v2'
-
-      - name: Configure Docker
-        run: gcloud auth configure-docker asia-northeast3-docker.pkg.dev
-
-      - name: Build and push Docker image to GCP Artifact Registry with cache
-        run: |
-          docker buildx create --use
-          docker buildx build --push --tag ${{ secrets.GCP_ARTIFACT_REGISTRY }}/tfinder:${{ github.sha }} \
-            --cache-from=type=registry,ref=${{ secrets.GCP_ARTIFACT_REGISTRY }}/tfinder:cache \
-            --cache-to=type=inline \
-            .
-
-      - name: Deploy to GCE instance
-        run: |
-          gcloud compute instances update-container "tfinder-vm" \
-            --zone "asia-northeast3-a" \
-            --container-image "${{ secrets.GCP_ARTIFACT_REGISTRY }}/tfinder:${{ github.sha }}"
+          host: 34.64.155.181
+          username: Icecoff22
+          key: ${{ secrets.UBUNTU_SSH_PRIVATE_KEY }}
+          port: 22
+          script: |
+            echo ${{ secrets.DOCKERHUB_PASSWORD }} | sudo docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+            sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${{github.sha}}
+            sudo docker tag ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:${{github.sha}} tfinder_server
+            sudo docker-compose down
+            sudo docker-compose up -d


### PR DESCRIPTION
- 기존 아티팩트 레지스트리 활용에서 docker hub 활용 배포로 수정
- 수정 이유는 https도입을 위해.
- 기존의 방식을 유지하기 위해선 container-optimized OS가 필수적
- ubuntu로 OS를 변경하고 docker hub를 이용하여 배포 자동화