### PR TITLE
[FEAT] 공지사항 조회 API 응답에 공지사항 상태값 추가

### DIFF
--- a/src/main/java/org/example/domain/notification/controller/NotificationController.java
+++ b/src/main/java/org/example/domain/notification/controller/NotificationController.java
@@ -37,11 +37,12 @@ public class NotificationController {
 
 
     @PostMapping("/")
-    @Operation(summary = "공지사항 생성", description = "공지사항 생성 API, 관리자만 접근 가능합니다.")
+    @Operation(summary = "공지사항 생성", description = "공지사항 생성 API, 관리자만 접근 가능합니다. \t\n "
+            + "UPDATED, GENERAL, EVENT 상태값만 허용합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(schema = @Schema(implementation = NotificationListResponseAll.class))),
-            @ApiResponse(responseCode = "400", description = "1. 제목 미입력 \\t\\n 2. 공지사항 분류 미선택",
+            @ApiResponse(responseCode = "400", description = "1. 제목 미입력 \t\n 2. 공지사항 분류 미선택",
                     content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
             @ApiResponse(responseCode = "500", description = "기타 서버 에러",
                     content = @Content(schema = @Schema(implementation = ErrorMessage.class))),

--- a/src/main/java/org/example/domain/notification/controller/dto/request/CreateNotificationRequest.java
+++ b/src/main/java/org/example/domain/notification/controller/dto/request/CreateNotificationRequest.java
@@ -1,5 +1,6 @@
 package org.example.domain.notification.controller.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -15,5 +16,6 @@ public class CreateNotificationRequest {
     private String description;
 
     @NotBlank(message = "공지사항 분류를 선택해주세요.")
+    @Schema(name = "상태값", description = "UPDATED, GENERAL, EVENT 상태값만 허용")
     private String state;
 }

--- a/src/main/java/org/example/domain/notification/controller/dto/response/NotificationListResponseAll.java
+++ b/src/main/java/org/example/domain/notification/controller/dto/response/NotificationListResponseAll.java
@@ -10,4 +10,5 @@ public class NotificationListResponseAll {
     private String title;
     private String description;
     private LocalDateTime createdAt;
+    private String state;
 }

--- a/src/main/java/org/example/domain/notification/domain/Notification.java
+++ b/src/main/java/org/example/domain/notification/domain/Notification.java
@@ -34,9 +34,9 @@ public class Notification extends BaseTimeEntity {
     private String description;
 
     @Column(name = "state", nullable = false)
-    private NotificationType state;
+    private String state;
 
-    public Notification(String title, String description, NotificationType type) {
+    public Notification(String title, String description, String type) {
         this.title = title;
         this.description = description;
         this.state = type;
@@ -50,7 +50,7 @@ public class Notification extends BaseTimeEntity {
             this.description = updateRequest.getDescription();
         }
         if (updateRequest.getState() != null) {
-            this.state = NotificationType.valueOf(updateRequest.getState());
+            this.state = NotificationType.valueOf(updateRequest.getState()).name();
         }
     }
 

--- a/src/main/java/org/example/domain/notification/domain/NotificationType.java
+++ b/src/main/java/org/example/domain/notification/domain/NotificationType.java
@@ -4,8 +4,12 @@ import lombok.Getter;
 
 @Getter
 public enum NotificationType {
-    UPDATED, GENERAL, EVENT;
+    UPDATED("업데이트"), GENERAL("일반"), EVENT("이벤트");
 
     private String type;
+
+    NotificationType(String type) {
+        this.type = type;
+    }
 
 }

--- a/src/main/java/org/example/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/example/domain/notification/repository/NotificationRepository.java
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findAllByOrderByCreatedAtDesc();
-    List<Notification> findByStateOrderByCreatedAtDesc(NotificationType state);
+    List<Notification> findByStateOrderByCreatedAtDesc(String state);
 }

--- a/src/main/java/org/example/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/example/domain/notification/service/NotificationService.java
@@ -26,7 +26,7 @@ public class NotificationService {
                 new Notification(
                         notificationRequest.getTitle(),
                         notificationRequest.getDescription(),
-                        NotificationType.valueOf(notificationRequest.getState())
+                        NotificationType.valueOf(notificationRequest.getState()).name()
                 ));
     }
 
@@ -41,7 +41,7 @@ public class NotificationService {
     }
 
     public List<NotificationListResponseAll> getStateNotificationList(NotificationType type) {
-        List<Notification> responseData = notificationRepository.findByStateOrderByCreatedAtDesc(type);
+        List<Notification> responseData = notificationRepository.findByStateOrderByCreatedAtDesc(type.name());
         List<NotificationListResponseAll> responseAllList = convertToResponseAllList(responseData);
 
         if (responseAllList.isEmpty()) {
@@ -55,7 +55,8 @@ public class NotificationService {
 
         for (Notification notification : responseData) {
             NotificationListResponseAll oneNotification = new NotificationListResponseAll(
-                    notification.getTitle(), notification.getDescription(), notification.getCreatedAt());
+                    notification.getTitle(), notification.getDescription(), notification.getCreatedAt(),
+                    NotificationType.valueOf(notification.getState()).getType());
             allList.add(oneNotification);
         }
 


### PR DESCRIPTION
- 상태값 db에 저장할 때 ENUM, number 대신 string 사용
- 이름을 명확히 하고자 함
- 현재 공지사항 상태값은 UPDATED, GENERAL, EVENT 존재