### PR TITLE
[FIX] 리프레시 토큰 쿠키가 서버로 오지 않는 현상 해결

### DIFF
--- a/src/main/java/org/example/domain/member/controller/MemberController.java
+++ b/src/main/java/org/example/domain/member/controller/MemberController.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.domain.member.dto.EmailVerificationResult;
 import org.example.domain.member.dto.request.UserSignInRequest;
 import org.example.domain.member.dto.request.UserSignUpRequest;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
+@Slf4j
 public class MemberController {
     private final MemberService memberService;
 
@@ -114,6 +116,7 @@ public class MemberController {
 
             Cookie cookie = new Cookie("RefreshToken", tokenInfo.getRefreshToken());
             cookie.setMaxAge(14 * 24 * 60 * 60);//expires in 2 weeks
+            cookie.setPath("/api/auth/reissue");
 
             cookie.setSecure(true);
             cookie.setHttpOnly(true);

--- a/src/main/java/org/example/domain/member/controller/Oauth2Controller.java
+++ b/src/main/java/org/example/domain/member/controller/Oauth2Controller.java
@@ -52,7 +52,7 @@ public class Oauth2Controller {
 
             Cookie cookie = new Cookie("RefreshToken", tokenInfo.getRefreshToken());
             cookie.setMaxAge(14*24*60*60);//expires in 2 weeks
-            cookie.setPath("/");
+            cookie.setPath("/api/auth/reissue");
 
             cookie.setSecure(true);//http통신에서는 전달x, https에서만 전달
             cookie.setHttpOnly(true);//XSS 예방

--- a/src/main/java/org/example/domain/member/controller/TokenController.java
+++ b/src/main/java/org/example/domain/member/controller/TokenController.java
@@ -55,6 +55,7 @@ public class TokenController {
 
             Cookie cookie = new Cookie("RefreshToken", tokenInfo.getRefreshToken());
             cookie.setMaxAge(14*24*60*60);//expires in 2 weeks
+            cookie.setPath("/api/auth/reissue");
 
             cookie.setSecure(true);
             cookie.setHttpOnly(true);

--- a/src/main/java/org/example/global/security/jwt/JwtProvider.java
+++ b/src/main/java/org/example/global/security/jwt/JwtProvider.java
@@ -9,6 +9,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import java.security.Key;
 import java.util.Arrays;
@@ -123,9 +124,23 @@ public class JwtProvider {
     }
 
     public String resolveRefreshToken(HttpServletRequest request) {
-        String bearerToken = request.getHeader(REFRESH_HEADER);
+        String bearerToken = getCookie(request);
         if (StringUtils.hasText(bearerToken)) {
             return bearerToken;
+        }
+        return null;
+    }
+
+    private String getCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie c : cookies) {
+                String name = c.getName();
+                String value = c.getValue();
+                if (name.equals(REFRESH_HEADER)) {
+                    return value;
+                }
+            }
         }
         return null;
     }


### PR DESCRIPTION
- cookie의 setpath가 원인
- 특정 path를 지정해주면 그 path에 대한 요청을 보낼 때 쿠키가 서버로 함께 온다.
- 기본 path defualt값은 쿠키 set하는 곳의 해당 controller의 requestMapping으로 적어준 값인 것으로 보임